### PR TITLE
implement wlr-output-management

### DIFF
--- a/include/monitor.h
+++ b/include/monitor.h
@@ -3,7 +3,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_damage.h>
-
+#include "server.h"
 #include "bitset/bitset.h"
 
 struct cursor;
@@ -41,6 +41,11 @@ void transform_monitor(struct monitor *m, enum wl_output_transform transform);
 void update_monitor_geometries();
 
 void monitor_set_selected_tag(struct monitor *m, struct tag *tag);
+
+void handle_output_mgr_apply(struct wl_listener *listener, void *data);
+void handle_output_mgr_test(struct wl_listener *listener, void *data);
+
+void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test);
 
 BitSet *monitor_get_tags(struct monitor *m);
 

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -43,9 +43,9 @@ void update_monitor_geometries();
 
 void monitor_set_selected_tag(struct monitor *m, struct tag *tag);
 
-static void handle_output_mgr_apply(struct wl_listener *listener, void *data);
-static void handle_output_mgr_test(struct wl_listener *listener, void *data);
-static void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test);
+void handle_output_mgr_apply(struct wl_listener *listener, void *data);
+void handle_output_mgr_test(struct wl_listener *listener, void *data);
+void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test);
 
 BitSet *monitor_get_tags(struct monitor *m);
 

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -3,6 +3,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_damage.h>
+
 #include "server.h"
 #include "bitset/bitset.h"
 
@@ -42,10 +43,9 @@ void update_monitor_geometries();
 
 void monitor_set_selected_tag(struct monitor *m, struct tag *tag);
 
-void handle_output_mgr_apply(struct wl_listener *listener, void *data);
-void handle_output_mgr_test(struct wl_listener *listener, void *data);
-
-void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test);
+static void handle_output_mgr_apply(struct wl_listener *listener, void *data);
+static void handle_output_mgr_test(struct wl_listener *listener, void *data);
+static void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test);
 
 BitSet *monitor_get_tags(struct monitor *m);
 

--- a/include/server.h
+++ b/include/server.h
@@ -90,8 +90,8 @@ struct server {
     struct wl_listener new_xdg_surface;
     struct wl_listener new_layer_shell_surface;
     struct wl_listener new_pointer_constraint;
-	  struct wl_listener output_mgr_apply;
-	  struct wl_listener output_mgr_test;
+    struct wl_listener output_mgr_apply;
+    struct wl_listener output_mgr_test;
 
     // TODO: give them a more sensible name they are here to fix a bug for
     // sloppy focus

--- a/include/server.h
+++ b/include/server.h
@@ -8,6 +8,7 @@
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
+#include <wlr/types/wlr_output_management_v1.h>
 #include <glib.h>
 #include <pthread.h>
 
@@ -38,6 +39,7 @@ struct server {
     struct wlr_relative_pointer_manager_v1 *relative_pointer_mgr;
     struct wlr_input_inhibit_manager *input_inhibitor_mgr;
     struct wlr_pointer_constraints_v1 *pointer_constraints;
+    struct wlr_output_manager_v1 *output_mgr;
 
     struct layout *default_layout;
     struct ring_buffer *default_layout_ring;
@@ -88,6 +90,8 @@ struct server {
     struct wl_listener new_xdg_surface;
     struct wl_listener new_layer_shell_surface;
     struct wl_listener new_pointer_constraint;
+	  struct wl_listener output_mgr_apply;
+	  struct wl_listener output_mgr_test;
 
     // TODO: give them a more sensible name they are here to fix a bug for
     // sloppy focus

--- a/meson.build
+++ b/meson.build
@@ -37,8 +37,6 @@ else
   add_project_arguments('-DDEBUG=0'.format(version), language: 'c')
 endif
 
-#for unstable features
-add_project_arguments('-DWLR_USE_UNSTABLE', language: 'c')
 
 datadir = get_option('datadir')
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,9 @@ else
   add_project_arguments('-DDEBUG=0'.format(version), language: 'c')
 endif
 
+#for unstable features
+add_project_arguments('-DWLR_USE_UNSTABLE', language: 'c')
+
 datadir = get_option('datadir')
 install_data(
     'japokwm.desktop',

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -390,15 +390,15 @@ void update_monitor_geometries()
     for (int i = 0; i < server.mons->len; i++) {
         struct monitor *m = g_ptr_array_index(server.mons, i);
         struct wlr_output_configuration_head_v1 *config_head = wlr_output_configuration_head_v1_create(config, m->wlr_output);
-        struct wlr_box *monitor_box = wlr_output_layout_get_box(server.output_layout, m->wlr_output);
 
         arrange_layers(m);
         arrange_monitor(m);
         config_head->state.enabled = m->wlr_output->enabled;
+        struct wlr_box *monitor_box = wlr_output_layout_get_box(server.output_layout, m->wlr_output);
         if (monitor_box) {
-			      config_head->state.x = monitor_box->x;
-			      config_head->state.y = monitor_box->y;
-		    }
+            config_head->state.x = monitor_box->x;
+            config_head->state.y = monitor_box->y;
+	}
     }
     wlr_output_manager_v1_set_configuration(server.output_mgr, config);
 }
@@ -478,17 +478,18 @@ void handle_output_mgr_apply(struct wl_listener *listener, void *data)
 }
 
 // apply_output_config
-void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test)
+void handle_output_mgr_apply_test(
+        struct wlr_output_configuration_v1 *config, bool test)
 {
-	struct wlr_output_configuration_head_v1 *config_head;
-	bool ok = true;
+    struct wlr_output_configuration_head_v1 *config_head;
+    bool output_ok = true;
 
-	wl_list_for_each(config_head, &config->heads, link) {
-		struct wlr_output *wlr_output = config_head->state.output;
+    wl_list_for_each(config_head, &config->heads, link) {
+	    struct wlr_output *wlr_output = config_head->state.output;
 
-		wlr_output_enable(wlr_output, config_head->state.enabled);
+	    wlr_output_enable(wlr_output, config_head->state.enabled);
 
-		if (config_head->state.enabled) {
+	    if (config_head->state.enabled) {
 			if (config_head->state.mode)
 				wlr_output_set_mode(wlr_output, config_head->state.mode);
 			else
@@ -504,18 +505,19 @@ void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bo
 		}
 
 		if (test) {
-			ok &= wlr_output_test(wlr_output);
+			output_ok &= wlr_output_test(wlr_output);
 			wlr_output_rollback(wlr_output);
-		} else
-			ok &= wlr_output_commit(wlr_output);
+                } else{
+			output_ok &= wlr_output_commit(wlr_output);
+                }
 	}
-	if (ok) {
+	if (output_ok) {
 		wlr_output_configuration_v1_send_succeeded(config);
 		if (!test)
 			update_monitor_geometries();
-	}
-	else
+	}else{
 		wlr_output_configuration_v1_send_failed(config);
+  }
 	wlr_output_configuration_v1_destroy(config);
 }
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -485,40 +485,40 @@ void handle_output_mgr_apply_test(
     bool output_ok = true;
 
     wl_list_for_each(config_head, &config->heads, link) {
-	    struct wlr_output *wlr_output = config_head->state.output;
+        struct wlr_output *wlr_output = config_head->state.output;
 
-	    wlr_output_enable(wlr_output, config_head->state.enabled);
+        wlr_output_enable(wlr_output, config_head->state.enabled);
 
-	    if (config_head->state.enabled) {
-			if (config_head->state.mode)
-				wlr_output_set_mode(wlr_output, config_head->state.mode);
-			else
-				wlr_output_set_custom_mode(wlr_output,
-						config_head->state.custom_mode.width,
-						config_head->state.custom_mode.height,
-						config_head->state.custom_mode.refresh);
+        if (config_head->state.enabled) {
+            if (config_head->state.mode)
+                wlr_output_set_mode(wlr_output, config_head->state.mode);
+            else
+		wlr_output_set_custom_mode(wlr_output,
+                        config_head->state.custom_mode.width,
+                        config_head->state.custom_mode.height,
+                        config_head->state.custom_mode.refresh);
 
-			wlr_output_layout_move(server.output_layout, wlr_output,
-					config_head->state.x, config_head->state.y);
-			wlr_output_set_transform(wlr_output, config_head->state.transform);
-			wlr_output_set_scale(wlr_output, config_head->state.scale);
-		}
+            wlr_output_layout_move(server.output_layout, wlr_output,
+                    config_head->state.x, config_head->state.y);
+            wlr_output_set_transform(wlr_output, config_head->state.transform);
+            wlr_output_set_scale(wlr_output, config_head->state.scale);
+        }
 
-		if (test) {
-			output_ok &= wlr_output_test(wlr_output);
+        if (test) {
+            output_ok &= wlr_output_test(wlr_output);
 			wlr_output_rollback(wlr_output);
-                } else{
+        } else{
 			output_ok &= wlr_output_commit(wlr_output);
-                }
-	}
-	if (output_ok) {
-		wlr_output_configuration_v1_send_succeeded(config);
-		if (!test)
-			update_monitor_geometries();
-	}else{
-		wlr_output_configuration_v1_send_failed(config);
-  }
-	wlr_output_configuration_v1_destroy(config);
+        }
+    }
+    if (output_ok) {
+        wlr_output_configuration_v1_send_succeeded(config);
+        if (!test)
+	    update_monitor_geometries();
+    }else{
+        wlr_output_configuration_v1_send_failed(config);
+    }
+    wlr_output_configuration_v1_destroy(config);
 }
 
 void handle_output_mgr_test(struct wl_listener *listener, void *data)

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -17,8 +17,8 @@
 #include "utils/parseConfigUtils.h"
 #include "layer_shell.h"
 #include "rules/mon_rule.h"
-#include "root.h"
 #include "tagset.h"
+#include "root.h"
 #include "list_sets/container_stack_set.h"
 #include "client.h"
 #include "container.h"
@@ -385,10 +385,22 @@ void transform_monitor(struct monitor *m, enum wl_output_transform transform)
 
 void update_monitor_geometries()
 {
+    struct wlr_output_configuration_v1 *config = wlr_output_configuration_v1_create();
+    
     for (int i = 0; i < server.mons->len; i++) {
         struct monitor *m = g_ptr_array_index(server.mons, i);
-        m->geom = *wlr_output_layout_get_box(server.output_layout, m->wlr_output);
+        struct wlr_output_configuration_head_v1 *config_head = wlr_output_configuration_head_v1_create(config, m->wlr_output);
+        struct wlr_box *monitor_box = wlr_output_layout_get_box(server.output_layout, m->wlr_output);
+
+        arrange_layers(m);
+        arrange_monitor(m);
+        config_head->state.enabled = m->wlr_output->enabled;
+        if (monitor_box) {
+			      config_head->state.x = monitor_box->x;
+			      config_head->state.y = monitor_box->y;
+		    }
     }
+    wlr_output_manager_v1_set_configuration(server.output_mgr, config);
 }
 
 void focus_monitor(struct monitor *m)
@@ -458,3 +470,59 @@ struct wlr_box monitor_get_active_geom(struct monitor *m)
     struct wlr_box geom = tag_get_active_geom(tag);
     return geom;
 }
+
+void handle_output_mgr_apply(struct wl_listener *listener, void *data)
+{
+	struct wlr_output_configuration_v1 *config = data;
+	handle_output_mgr_apply_test(config, false);
+}
+
+// apply_output_config
+void handle_output_mgr_apply_test(struct wlr_output_configuration_v1 *config, bool test)
+{
+	struct wlr_output_configuration_head_v1 *config_head;
+	bool ok = true;
+
+	wl_list_for_each(config_head, &config->heads, link) {
+		struct wlr_output *wlr_output = config_head->state.output;
+
+		wlr_output_enable(wlr_output, config_head->state.enabled);
+
+		if (config_head->state.enabled) {
+			if (config_head->state.mode)
+				wlr_output_set_mode(wlr_output, config_head->state.mode);
+			else
+				wlr_output_set_custom_mode(wlr_output,
+						config_head->state.custom_mode.width,
+						config_head->state.custom_mode.height,
+						config_head->state.custom_mode.refresh);
+
+			wlr_output_layout_move(server.output_layout, wlr_output,
+					config_head->state.x, config_head->state.y);
+			wlr_output_set_transform(wlr_output, config_head->state.transform);
+			wlr_output_set_scale(wlr_output, config_head->state.scale);
+		}
+
+		if (test) {
+			ok &= wlr_output_test(wlr_output);
+			wlr_output_rollback(wlr_output);
+		} else
+			ok &= wlr_output_commit(wlr_output);
+	}
+	if (ok) {
+		wlr_output_configuration_v1_send_succeeded(config);
+		if (!test)
+			update_monitor_geometries();
+	}
+	else
+		wlr_output_configuration_v1_send_failed(config);
+	wlr_output_configuration_v1_destroy(config);
+}
+
+void handle_output_mgr_test(struct wl_listener *listener, void *data)
+{
+	struct wlr_output_configuration_v1 *config = data;
+  handle_output_mgr_apply_test(config, true);
+}
+
+

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -27,6 +27,9 @@ static void handle_output_damage_frame(struct wl_listener *listener, void *data)
 static void handle_output_frame(struct wl_listener *listener, void *data);
 static void handle_output_mode(struct wl_listener *listener, void *data);
 static void monitor_get_initial_tag(struct monitor *m, GList *tags);
+static void prepare_output(struct wlr_output_configuration_head_v1 *config_head, struct wlr_output *wlr_output);
+static void check_succeed(struct wlr_output_configuration_v1 *config, bool output_ok, bool test);
+static bool output_test(struct wlr_output *wlr_output, bool output_ok, bool test);
 
 void create_monitor(struct wl_listener *listener, void *data)
 {
@@ -394,7 +397,7 @@ void update_monitor_geometries()
         arrange_layers(m);
         arrange_monitor(m);
         config_head->state.enabled = m->wlr_output->enabled;
-        struct wlr_box *monitor_box = wlr_output_layout_get_box(server.output_layout, m->wlr_output);
+        struct wlr_box *monitor_box = &m->geom;
         if (monitor_box) {
             config_head->state.x = monitor_box->x;
             config_head->state.y = monitor_box->y;
@@ -483,41 +486,14 @@ void handle_output_mgr_apply_test(
 {
     struct wlr_output_configuration_head_v1 *config_head;
     bool output_ok = true;
-
     wl_list_for_each(config_head, &config->heads, link) {
         struct wlr_output *wlr_output = config_head->state.output;
 
         wlr_output_enable(wlr_output, config_head->state.enabled);
-
-        if (config_head->state.enabled) {
-            if (config_head->state.mode)
-                wlr_output_set_mode(wlr_output, config_head->state.mode);
-            else
-		wlr_output_set_custom_mode(wlr_output,
-                        config_head->state.custom_mode.width,
-                        config_head->state.custom_mode.height,
-                        config_head->state.custom_mode.refresh);
-
-            wlr_output_layout_move(server.output_layout, wlr_output,
-                    config_head->state.x, config_head->state.y);
-            wlr_output_set_transform(wlr_output, config_head->state.transform);
-            wlr_output_set_scale(wlr_output, config_head->state.scale);
-        }
-
-        if (test) {
-            output_ok &= wlr_output_test(wlr_output);
-			wlr_output_rollback(wlr_output);
-        } else{
-			output_ok &= wlr_output_commit(wlr_output);
-        }
+       prepare_output(config_head, wlr_output);
+       output_ok = output_test(wlr_output, output_ok, test);
     }
-    if (output_ok) {
-        wlr_output_configuration_v1_send_succeeded(config);
-        if (!test)
-	    update_monitor_geometries();
-    }else{
-        wlr_output_configuration_v1_send_failed(config);
-    }
+    check_succeed(config, output_ok, test);
     wlr_output_configuration_v1_destroy(config);
 }
 
@@ -527,4 +503,45 @@ void handle_output_mgr_test(struct wl_listener *listener, void *data)
   handle_output_mgr_apply_test(config, true);
 }
 
+static void prepare_output(
+        struct wlr_output_configuration_head_v1 *config_head,
+        struct wlr_output *wlr_output)
+{
+    if (config_head->state.enabled) {
+        if (config_head->state.mode)
+            wlr_output_set_mode(wlr_output, config_head->state.mode);
+        else
+            wlr_output_set_custom_mode(wlr_output,
+                    config_head->state.custom_mode.width,
+                    config_head->state.custom_mode.height,
+                    config_head->state.custom_mode.refresh);
 
+        wlr_output_layout_move(server.output_layout, wlr_output,
+                config_head->state.x, config_head->state.y);
+        wlr_output_set_transform(wlr_output, config_head->state.transform);
+        wlr_output_set_scale(wlr_output, config_head->state.scale);
+    }
+}
+
+static bool output_test(struct wlr_output *wlr_output, bool output_ok,
+        bool test)
+{
+    if (test) {
+        output_ok &= wlr_output_test(wlr_output);
+                    wlr_output_rollback(wlr_output);
+    } else{
+                    output_ok &= wlr_output_commit(wlr_output);
+    }
+    return output_ok;
+}    
+static void check_succeed(struct wlr_output_configuration_v1 *config,
+        bool output_ok, bool test)
+{
+    if (output_ok) {
+        wlr_output_configuration_v1_send_succeeded(config);
+        if (!test)
+	    update_monitor_geometries();
+    }else{
+        wlr_output_configuration_v1_send_failed(config);
+    }
+}

--- a/src/server.c
+++ b/src/server.c
@@ -337,7 +337,6 @@ int setup(struct server *server)
     drw = wlr_backend_get_renderer(server->backend);
     wlr_renderer_init_wl_display(drw, server->wl_display);
 
-
     /* This creates some hands-off wlroots interfaces. The compositor is
      * necessary for clients to allocate surfaces and the data device manager
      * handles the clipboard. Each of these wlroots interfaces has room for you

--- a/src/server.c
+++ b/src/server.c
@@ -170,6 +170,11 @@ static void init_event_handlers(struct server *server)
 
     server->pointer_constraints = wlr_pointer_constraints_v1_create(server->wl_display);
     LISTEN(&server->pointer_constraints->events.new_constraint, &server->new_pointer_constraint, handle_new_pointer_constraint);
+
+    server->output_mgr = wlr_output_manager_v1_create(server->wl_display);
+    LISTEN(&server->output_mgr->events.apply, &server->output_mgr_apply, handle_output_mgr_apply);
+    LISTEN(&server->output_mgr->events.test, &server->output_mgr_test, handle_output_mgr_test);
+
 }
 
 static void finalize_event_handlers(struct server *server)
@@ -332,6 +337,7 @@ int setup(struct server *server)
     drw = wlr_backend_get_renderer(server->backend);
     wlr_renderer_init_wl_display(drw, server->wl_display);
 
+
     /* This creates some hands-off wlroots interfaces. The compositor is
      * necessary for clients to allocate surfaces and the data device manager
      * handles the clipboard. Each of these wlroots interfaces has room for you
@@ -383,6 +389,10 @@ int setup(struct server *server)
     server->input_manager = create_input_manager();
     struct seat *seat = create_seat("seat0");
     g_ptr_array_add(server->input_manager->seats, seat);
+    
+   server->output_mgr=wlr_output_manager_v1_create(server->wl_display); 
+    wl_signal_add(&server->output_mgr->events.apply, &server->output_mgr_apply);
+    wl_signal_add(&server->output_mgr->events.test, &server->output_mgr_test);
 
 #ifdef JAPOKWM_HAS_XWAYLAND
     init_xwayland(server->wl_display, seat);


### PR DESCRIPTION
this gives us basic support for automatic scaling using using programs like Kanshi. Alacritty is known not to scale properly so will test more to find reason. This is otherwise usable